### PR TITLE
Handle non parameterized builds, that become parameterized after the first run

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ async function requestJenkinsJob(jobName, params, headers) {
   const req = {
     method: 'POST',
     url: `${jenkinsEndpoint}/job/${jobName}${isParameterized ? '/buildWithParameters' : '/build'}`,
-    form: isParameterized ? params : {},
+    form: isParameterized ? params : undefined,
     headers: headers
   };
   await new Promise((resolve, reject) => request(req)
@@ -94,7 +94,7 @@ async function waitJenkinsJob(jobName, timestamp, headers) {
 async function main() {
   try {
     // User input params
-    let params = undefined;
+    let params = {};
     let startTs = + new Date();
     let jobName = core.getInput('job_name');
     if (core.getInput('parameter')) {

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ async function main() {
     // User input params
     let params = {};
     let startTs = + new Date();
-    let jobName = encodeURIComponent(core.getInput('job_name'));
+    let jobName = core.getInput('job_name');
     if (core.getInput('parameter')) {
       params = JSON.parse(core.getInput('parameter'));
       core.info(`>>> Parameter ${params.toString()}`);

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ async function getJobStatus(jobName, headers) {
         try {
         resolve(JSON.parse(body));
         } catch(err) {
-          core.info(`Failed to parse body err: ${err}, body: ${body}`});
+          core.info(`Failed to parse body err: ${err}, body: ${body}`);
           resolve({timestamp: 0}); // try again
         }
       })

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ async function requestJenkinsJob(jobName, params, headers) {
         clearTimeout(timer);
         reject();
       }
-      resolve(!!(body.search("ParametersDefinitionProperty")));
+      resolve(body.search("ParametersDefinitionProperty") >= 0);
     })
   );
   const req = {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ async function requestJenkinsJob(jobName, params, headers) {
   const jenkinsEndpoint = core.getInput('url');
   const req = {
     method: 'POST',
-    url: `${jenkinsEndpoint}/job/${jobName}/buildWithParameters`,
+    url: `${jenkinsEndpoint}/job/${jobName}${params ? '/buildWithParameters' : '/build'}`,
     form: params,
     headers: headers
   }

--- a/index.js
+++ b/index.js
@@ -14,12 +14,29 @@ const sleep = (seconds) => {
 
 async function requestJenkinsJob(jobName, params, headers) {
   const jenkinsEndpoint = core.getInput('url');
+
+  const jsonReq = {
+    method: 'GET',
+    url: `${jenkinsEndpoint}/job/${jobName}/api/json`,
+    headers: headers
+  };
+  const isParameterized = await new Promise((resolve, reject) => 
+    request(jsonReq, (err, res, body) => {
+      if (err) {
+        core.setFailed(err);
+        core.error(JSON.stringify(err));
+        clearTimeout(timer);
+        reject();
+      }
+      resolve(!!(body.search("ParametersDefinitionProperty")));
+    })
+  );
   const req = {
     method: 'POST',
-    url: `${jenkinsEndpoint}/job/${jobName}${params ? '/buildWithParameters' : '/build'}`,
-    form: params || {},
+    url: `${jenkinsEndpoint}/job/${jobName}${isParameterized ? '/buildWithParameters' : '/build'}`,
+    form: isParameterized ? params : {},
     headers: headers
-  }
+  };
   await new Promise((resolve, reject) => request(req)
     .on('response', (res) => {
       core.info(`>>> Job is started!`);

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ async function main() {
     // User input params
     let params = {};
     let startTs = + new Date();
-    let jobName = core.getInput('job_name');
+    let jobName = encodeURIComponent(core.getInput('job_name'));
     if (core.getInput('parameter')) {
       params = JSON.parse(core.getInput('parameter'));
       core.info(`>>> Parameter ${params.toString()}`);

--- a/index.js
+++ b/index.js
@@ -47,7 +47,12 @@ async function getJobStatus(jobName, headers) {
           clearTimeout(timer);
           reject(err);
         }
+        try {
         resolve(JSON.parse(body));
+        } catch(err) {
+          core.info(`Failed to parse body err: ${err}, body: ${body}`});
+          resolve({timestamp: 0}); // try again
+        }
       })
     );
 }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ async function requestJenkinsJob(jobName, params, headers) {
   const req = {
     method: 'POST',
     url: `${jenkinsEndpoint}/job/${jobName}${params ? '/buildWithParameters' : '/build'}`,
-    form: params,
+    form: params || {},
     headers: headers
   }
   await new Promise((resolve, reject) => request(req)
@@ -72,7 +72,7 @@ async function waitJenkinsJob(jobName, timestamp, headers) {
 async function main() {
   try {
     // User input params
-    let params = {};
+    let params = undefined;
     let startTs = + new Date();
     let jobName = core.getInput('job_name');
     if (core.getInput('parameter')) {


### PR DESCRIPTION
The intention of these changes is for multibranch jobs where it is not considered parameterized until there has been an initial run.
I do a basic check on the builds /api/json to check if its parameterized and then base if i call /build or /buildWithParams from that.

I've also wrapped the status check in a try/catch as if you're too fast, the lastBuild can throw a 404. Unsure if it'd be worth limiting how many times we allow for that but if it's queued I think it could take a reasonable amount of time.